### PR TITLE
Unobsolete the coilgun and nail magazine

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/magazines.json
@@ -307,7 +307,7 @@
     "type": "item_group",
     "id": "mags_other_makeshift",
     "//": "Makeshift or otherwise poor quality magazines that have no better category.",
-    "items": [ [ "pressurized_tank_chem", 5 ], [ "aux_pressurized_tank", 10 ] ]
+    "items": [ [ "nailmag", 20 ], [ "pressurized_tank_chem", 5 ], [ "aux_pressurized_tank", 10 ] ]
   },
   {
     "type": "item_group",

--- a/data/json/items/ammo/nail.json
+++ b/data/json/items/ammo/nail.json
@@ -8,7 +8,7 @@
     "material": [ "steel" ],
     "symbol": "=",
     "color": "dark_gray",
-    "proportional": { "price": 3, "damage": { "damage_type": "stab", "amount": 3.0, "armor_penetration": 3.0 } }
+    "proportional": { "price": 3, "range": 2.0, "damage": { "damage_type": "stab", "amount": 2.0 }, "dispersion": 0.5 }
   },
   {
     "id": "nail",

--- a/data/json/items/gun/nail.json
+++ b/data/json/items/gun/nail.json
@@ -24,5 +24,46 @@
     "reload": 50,
     "valid_mod_locations": [ [ "grip mount", 1 ], [ "rail mount", 1 ], [ "sights mount", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "nail": 20 } } ]
+  },
+  {
+    "id": "coilgun",
+    "copy-from": "gun_base",
+    "looks_like": "ar15",
+    "type": "GUN",
+    "name": { "str": "coilgun" },
+    "//": "Hard to make, plentiful and cheap ammo, and silent - people will want this thing.",
+    "description": "A homemade gun, using electromagnets to accelerate a ferromagnetic projectile to high velocity.  Powered by UPS.",
+    "weight": "2041 g",
+    "volume": "2750 ml",
+    "price": 75000,
+    "price_postapoc": 5000,
+    "to_hit": -2,
+    "bashing": 10,
+    "material": [ "copper", "steel" ],
+    "ammo": [ "nail" ],
+    "skill": "rifle",
+    "range": 12,
+    "ranged_damage": { "damage_type": "stab", "amount": 1 },
+    "dispersion": 180,
+    "durability": 5,
+    "ups_charges": 1,
+    "valid_mod_locations": [
+      [ "accessories", 4 ],
+      [ "grip", 1 ],
+      [ "sights", 1 ],
+      [ "sling", 1 ],
+      [ "stock", 1 ],
+      [ "rail mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "holster": true,
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "item_restriction": [ "nailmag" ]
+      }
+    ]
   }
 ]

--- a/data/json/items/magazine/nail.json
+++ b/data/json/items/magazine/nail.json
@@ -1,0 +1,20 @@
+[
+  {	
+    "id": "nailmag",	
+    "looks_like": "stanag30",	
+    "type": "MAGAZINE",	
+    "name": { "str": "nail rifle magazine" },	
+    "description": "An improvised magazine for use with a coilgun.  Little more than a metal box, spring and some duct tape it is awkward to reload and not especially reliable.",	
+    "weight": "60 g",	
+    "volume": "250 ml",	
+    "price": 1920,	
+    "material": "steel",	
+    "symbol": "#",	
+    "color": "light_gray",	
+    "ammo_type": "nail",	
+    "capacity": 50,	
+    "reliability": 6,	
+    "reload_time": 300,	
+    "flags": [ "MAG_COMPACT" ]	
+  }
+]

--- a/data/json/items/obsolete.json
+++ b/data/json/items/obsolete.json
@@ -2220,47 +2220,6 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "metal_rail": 1 } } ]
   },
   {
-    "id": "coilgun",
-    "copy-from": "gun_base",
-    "looks_like": "ar15",
-    "type": "GUN",
-    "name": { "str": "coilgun" },
-    "//": "Hard to make, plentiful and cheap ammo, and silent - people will want this thing.",
-    "description": "A homemade gun, using electromagnets to accelerate a ferromagnetic projectile to high velocity.  Powered by UPS.",
-    "weight": "3341 g",
-    "volume": "2750 ml",
-    "price": 75000,
-    "price_postapoc": 5000,
-    "to_hit": -2,
-    "bashing": 10,
-    "material": [ "copper", "steel" ],
-    "ammo": [ "nail" ],
-    "skill": "rifle",
-    "range": 12,
-    "ranged_damage": { "damage_type": "stab", "amount": 4, "armor_penetration": 20 },
-    "dispersion": 180,
-    "durability": 5,
-    "ups_charges": 5,
-    "valid_mod_locations": [
-      [ "accessories", 4 ],
-      [ "grip", 1 ],
-      [ "sights", 1 ],
-      [ "sling", 1 ],
-      [ "stock", 1 ],
-      [ "rail mount", 1 ],
-      [ "underbarrel mount", 1 ]
-    ],
-    "pocket_data": [
-      {
-        "pocket_type": "MAGAZINE_WELL",
-        "holster": true,
-        "max_contains_volume": "20 L",
-        "max_contains_weight": "20 kg",
-        "item_restriction": [ "nailmag" ]
-      }
-    ]
-  },
-  {
     "id": "nailrifle",
     "copy-from": "nailgun",
     "looks_like": "ar15",
@@ -2293,24 +2252,6 @@
         "item_restriction": [ "nailmag" ]
       }
     ]
-  },
-  {
-    "id": "nailmag",
-    "looks_like": "stanag30",
-    "type": "MAGAZINE",
-    "name": { "str": "nail rifle magazine" },
-    "description": "An improvised magazine for use with a nail rifle.  Little more than a tin can, spring and some duct tape it is awkward to reload and not especially reliable.",
-    "weight": "60 g",
-    "volume": "250 ml",
-    "price": 1920,
-    "material": [ "steel" ],
-    "symbol": "#",
-    "color": "light_gray",
-    "ammo_type": [ "nail" ],
-    "capacity": 50,
-    "reload_time": 300,
-    "flags": [ "MAG_COMPACT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "nail": 50 } } ]
   },
   {
     "id": "recipe_mininuke_launch",

--- a/data/json/obsolete.json
+++ b/data/json/obsolete.json
@@ -1160,17 +1160,7 @@
     "obsolete": true
   },
   {
-    "type": "recipe",
-    "result": "coilgun",
-    "obsolete": true
-  },
-  {
     "result": "nailrifle",
-    "type": "recipe",
-    "obsolete": true
-  },
-  {
-    "result": "nailmag",
     "type": "recipe",
     "obsolete": true
   },
@@ -1213,20 +1203,6 @@
     "color": "magenta",
     "broken_color": "magenta",
     "breaks_into": [ { "item": "scrap", "count": 9 }, { "item": "steel_chunk", "count": 5 }, { "item": "steel_lump", "count": 2 } ],
-    "requirements": {
-      "install": { "skills": [ [ "mechanics", 5 ], [ "electronics", 5 ] ] },
-      "removal": { "skills": [ [ "mechanics", 3 ] ] }
-    }
-  },
-  {
-    "id": "mounted_coilgun",
-    "copy-from": "turret",
-    "type": "vehicle_part",
-    "name": { "str": "mounted coilgun" },
-    "item": "coilgun",
-    "color": "magenta",
-    "broken_color": "magenta",
-    "breaks_into": [ { "item": "scrap", "count": 13 }, { "item": "steel_chunk", "count": 4 }, { "item": "steel_lump", "count": 1 } ],
     "requirements": {
       "install": { "skills": [ [ "mechanics", 5 ], [ "electronics", 5 ] ] },
       "removal": { "skills": [ [ "mechanics", 3 ] ] }

--- a/data/json/recipes/recipe_weapon.json
+++ b/data/json/recipes/recipe_weapon.json
@@ -2567,5 +2567,30 @@
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "leather", 30 ], [ "rope_superior_short", 2, "LIST" ] ], [ [ "scrap", 9 ], [ "razor_blade", 9 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "result": "coilgun",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_RANGED",
+    "skill_used": "electronics",	
+    "skills_required": [ [ "computer", 3 ], [ "fabrication", 3 ] ],
+    "difficulty": 5,
+    "time": "4 h",
+    "reversible": true,
+    "book_learn": [ [ "advanced_electronics", 5 ], [ "textbook_electronics", 5 ], [ "textbook_anarch", 6 ] ],
+    "using": [ [ "soldering_standard", 20 ], [ "surface_heat", 10 ] ],
+    "qualities": [ { "id": "SAW_M_FINE", "level": 1 }, { "id": "SCREW", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
+    "tools": [ [ [ "mold_plastic", -1 ] ], [ [ "laptop", -1 ] ] ],
+    "components": [
+      [ [ "plastic_chunk", 10 ] ],
+      [ [ "superglue", 1 ] ],
+      [ [ "processor", 1 ] ],
+      [ [ "circuit", 2 ] ],
+      [ [ "power_supply", 2 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "e_scrap", 30 ] ],
+      [ [ "scrap", 10 ] ],
+      [ [ "cable", 100 ] ] ]
   }
 ]

--- a/data/json/recipes/weapon/magazines.json
+++ b/data/json/recipes/weapon/magazines.json
@@ -362,5 +362,23 @@
     "using": [ [ "welding_standard", 2 ] ],
     "qualities": [ { "id": "HAMMER", "level": 2 } ],
     "components": [ [ [ "metal_tank_little", 1 ] ] ]
+  },
+  {	
+    "result": "nailmag",
+    "type": "recipe",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MAGAZINES",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "time": "8 m",
+    "autolearn": true,
+    "tools": [ [ [ "coilgun", -1 ] ], [ [ "nail", -1 ], [ "combatnail", -1 ] ] ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 } ],
+    "components": [	
+      [ [ "sheet_metal_small", 1 ] ],
+      [ [ "spring", 1 ] ],
+      [ [ "scrap", 1 ] ],
+      [ [ "duct_tape", 20 ] ]
+    ]	
   }
 ]


### PR DESCRIPTION
#### Summary

SUMMARY: Content "Bring back the previously obsoleted coilgun"

#### Purpose of change

Coilguns are an item that exist in the real world, which are produced by hobbyists in garages/workshops using tools, materials, and skills that the player character could feasibly acquire in the Cataclysm. They are not especially lethal in comparison to powder-based firearms, but they are still dangerous and capable of inflicting wounds from a distance, and might be preferable in some cases due to their relative silence and availability of ammunition.

#### Describe the solution

The coilgun was obsoleted due to its unrealistic implementation. This PR alters the recipe and stats for the coilgun so that it meets current standards. 

The skills required to craft the coilgun have been expanded and increased. Electronics 5 accounts for the circuitry of the coilgun itself, as well as for the usage of a UPS to power a home-made device - Electronics 5 is similarly required to craft a UPS conversion mod. Computers 3 accounts for the basic programming skill needed to set up the sensors and timing involved in the firing sequence of the gun. Fabrication 3 accounts for putting everything together in a gun-like construction made of plastic and metal that the player can comfortably wield.
A laptop has been added as a tool needed to craft the coilgun, for the player to interface with and program it. A plastic mold has also been added, self-explanatory.
The time to craft was increased to from 1 to 4 hours, taking up an entire evening instead of such a low amount of time for a somewhat complicated project.
The crafting materials were expanded and increased. Plastic chunks and scrap metal make up the structure of the coilgun. A processor board, amplifier circuit, circuit boards, and electronic scraps make up the circuitry. Some electronic scraps specifically represent photodiodes and LEDs used to track the projectile's position within the barrel. Power converters supply power to the gun and coils. A considerable amount of copper wire is used to make the eponymous coils.

The damage of the coilgun as well as flechettes have been lowered to be just under that of the weakest pistol available (Ruger LCR .22). It was noted in the comments of the previously mentioned PR that the coilgun's damage should be lowered to less than that of a pistol. The armor piercing capability of the coilgun has also been removed, so that it can only completely pierce a few layers of cotton clothing. The range and accuracy of flechettes have also been buffed, to reflect the fact that they have fins to stabilize their flight, unlike normal nails.

#### Describe alternatives you've considered

Adding "large capacitor"s as an item for use in the coilgun's recipe - I consider this unnecessary due to the existence of coilguns which do not utilize large capacitor batteries, as well as the fact that the coilgun runs off of a UPS, which can presumably provide all of the power capacitors would provide and then some.
Adding support for multiple magazine/ammo-types in guns, so that the coilgun can use both normal batteries and nails - I do not have the programming knowledge or familiarity with the code to implement such a change.

#### Testing

Made the items available using a small mod.
Spawned and test-fired the items.

#### Additional context
